### PR TITLE
Fix Vercel config for frontend-only deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Build powerful AI workflows using a visual, no-code interface. hirewise.ai helps
   - FastAPI backend in `apps/api` managed with **Poetry**
   - Next.js frontend in `apps/web`
 - 🚀 **Production Ready**:
-  - Vercel deployment support
+  - Vercel frontend deployment
+  - Fly.io backend deployment
   - PNPM package management
   - Custom cursor interactions
   - Responsive design
@@ -23,7 +24,7 @@ Build powerful AI workflows using a visual, no-code interface. hirewise.ai helps
 - **Frontend**: Next.js 15, Radix UI, TailwindCSS
 - **Backend**: Python 3.13, FastAPI
 - **Build Tools**: Turborepo, PNPM
-- **Deployment**: Vercel
+- **Deployment**: Vercel (frontend) & Fly.io (backend)
 
 ## Getting Started
 
@@ -52,35 +53,13 @@ Build powerful AI workflows using a visual, no-code interface. hirewise.ai helps
 
 4. **Build and Deploy**
 
-   There are two deployment options available:
+    Deploy the frontend to Vercel. The FastAPI backend is deployed separately on Fly.io.
 
-   ### Full Stack Deployment (Default)
-
-   The default deployment includes both the Next.js frontend and Python FastAPI backend as serverless functions.
-
-   ```bash
-   # Build all packages and applications
-   pnpm build
-
-   # Deploy to Vercel
-   vercel
-   ```
-
-   The Python backend will be automatically deployed as serverless functions using Vercel's Python runtime. Make sure your `vercel.json` is properly configured with the Python build settings.
-
-   ### Web-Only Deployment
-
-   For deploying just the Next.js frontend:
-
-   ```bash
-   # Build the web application
-   cd apps/web && pnpm build
-
-   # Deploy using web-only configuration
-   vercel --config vercel-web-only.json
-   ```
-
-   This will deploy only the Next.js application without the Python backend.
+    ```bash
+    cd apps/web
+    pnpm build
+    vercel
+    ```
 
 ## Documentation
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/vercel-web-only.json
+++ b/vercel-web-only.json
@@ -1,8 +1,0 @@
-{
-  "version": 2,
-  "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "cd apps/web && pnpm build",
-  "devCommand": "cd apps/web && pnpm dev",
-  "outputDirectory": "apps/web/.next",
-  "framework": "nextjs"
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,26 +1,8 @@
 {
   "version": 2,
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "turbo build",
-  "builds": [
-    {
-      "src": "apps/web/package.json",
-      "use": "@vercel/next"
-    },
-    {
-      "src": "apps/api/vercel.py",
-      "use": "@vercel/python",
-      "config": { "maxLambdaSize": "50mb" }
-    }
-  ],
-  "routes": [
-    {
-      "src": "/api/(.*)",
-      "dest": "apps/api/vercel.py"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "apps/web/$1"
-    }
-  ]
+  "buildCommand": "cd apps/web && pnpm build",
+  "devCommand": "cd apps/web && pnpm dev",
+  "outputDirectory": "apps/web/.next",
+  "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- deploy only the Next.js app on Vercel
- drop turbopack from the web dev script
- document Fly.io backend and updated deploy steps

## Testing
- `pnpm --version` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_b_6839f0f7af68832b9c512b36aeaabae6