### PR TITLE
Fix Fly config and Dockerfile

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim
+
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+RUN pip install --no-cache-dir poetry
+
+# Copy project metadata
+COPY apps/api/pyproject.toml apps/api/poetry.lock* ./
+
+# Include the local database package so Poetry can install it
+COPY packages/database ./packages/database
+
+# Install dependencies without dev packages and without creating a venv
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-dev --no-interaction --no-ansi
+
+# Copy the API source after dependencies are installed
+COPY apps/api ./
+
+EXPOSE 8000
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- install Python dependencies system-wide without a virtualenv
- include the local `packages/database` package during the Docker build
- update `fly.toml` to build from the repo root
- keep Next.js rewrite to forward API requests to the Fly deployment

## Testing
- `python -m pytest apps/api/tests/test_auth.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_683a2513fb40832bb8f7cf35e5906880