### PR TITLE
Add auth UI pages

### DIFF
--- a/apps/web/src/app/(auth)/reset-password/page.tsx
+++ b/apps/web/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { Card, Flex, Heading, Text, Button } from '@radix-ui/themes';
+import * as Form from '@radix-ui/react-form';
+import React, { useState } from 'react';
+import { AuthManager } from '@/lib/auth';
+import { Logo } from '@/components/ui/logo';
+
+export default function ResetPasswordPage() {
+  const [requestMessage, setRequestMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const handleRequest = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    const formData = new FormData(event.currentTarget);
+    const email = formData.get('email') as string;
+    if (!email) return;
+
+    try {
+      await AuthManager.requestPasswordReset(email);
+      setRequestMessage('Check your email for reset instructions.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send reset email');
+    }
+  };
+
+  const handleReset = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    const formData = new FormData(event.currentTarget);
+    const token = formData.get('reset_token') as string;
+    const password = formData.get('new_password') as string;
+    if (!token || !password) return;
+
+    try {
+      await AuthManager.resetPassword({ reset_token: token, new_password: password });
+      setSuccess('Password reset successfully. You can now log in.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Password reset failed');
+    }
+  };
+
+  return (
+    <Card size="4" style={{ backgroundColor: 'white', width: '100%' }} variant="surface">
+      <Flex direction="column" gap="4" className="mt-0">
+        <Heading size="6" align="center" mx="0" className="flex flex-col items-center mt-0">
+          <Logo width={250} height={100} className="mb-4 mx-auto" />
+          <Text size="5" weight="medium">
+            Reset Password
+          </Text>
+        </Heading>
+
+        {error && (
+          <Text color="red" size="2" align="center">
+            {error}
+          </Text>
+        )}
+        {requestMessage && (
+          <Text color="green" size="2" align="center">
+            {requestMessage}
+          </Text>
+        )}
+        {success && (
+          <Text color="green" size="2" align="center">
+            {success}
+          </Text>
+        )}
+
+        <Form.Root onSubmit={handleRequest} className="space-y-3">
+          <Form.Field name="email">
+            <Form.Label>
+              <Text size="2" weight="medium">
+                Email
+              </Text>
+            </Form.Label>
+            <Form.Control asChild>
+              <input
+                type="email"
+                name="email"
+                placeholder="Enter your email"
+                required
+                className="w-full px-3 py-2 text-base bg-white border rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500"
+              />
+            </Form.Control>
+            <Form.Message match="valueMissing">
+              <Text size="1" color="red">
+                Please enter your email
+              </Text>
+            </Form.Message>
+            <Form.Message match="typeMismatch">
+              <Text size="1" color="red">
+                Please enter a valid email
+              </Text>
+            </Form.Message>
+          </Form.Field>
+          <Form.Submit asChild>
+            <Button size="3" style={{ width: '100%', marginTop: '10px' }}>
+              Send Reset Email
+            </Button>
+          </Form.Submit>
+        </Form.Root>
+
+        <Form.Root onSubmit={handleReset} className="space-y-3 mt-6">
+          <Form.Field name="reset_token">
+            <Form.Label>
+              <Text size="2" weight="medium">
+                Reset Token
+              </Text>
+            </Form.Label>
+            <Form.Control asChild>
+              <input
+                type="text"
+                name="reset_token"
+                placeholder="Token"
+                required
+                className="w-full px-3 py-2 text-base bg-white border rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500"
+              />
+            </Form.Control>
+          </Form.Field>
+          <Form.Field name="new_password">
+            <Form.Label>
+              <Text size="2" weight="medium">
+                New Password
+              </Text>
+            </Form.Label>
+            <Form.Control asChild>
+              <input
+                type="password"
+                name="new_password"
+                placeholder="Enter new password"
+                required
+                className="w-full px-3 py-2 text-base bg-white border rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500"
+              />
+            </Form.Control>
+          </Form.Field>
+          <Form.Submit asChild>
+            <Button size="3" style={{ width: '100%', marginTop: '10px' }}>
+              Reset Password
+            </Button>
+          </Form.Submit>
+        </Form.Root>
+      </Flex>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(auth)/sign-up/page.tsx
+++ b/apps/web/src/app/(auth)/sign-up/page.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { Card, Flex, Heading, Text, Button, Select } from '@radix-ui/themes';
+import * as Form from '@radix-ui/react-form';
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { AuthManager } from '@/lib/auth';
+import { Logo } from '@/components/ui/logo';
+
+export default function SignUpPage() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsLoading(true);
+    setError(null);
+
+    const formData = new FormData(event.currentTarget);
+    const email = formData.get('email') as string;
+    const password = formData.get('password') as string;
+    const firstName = formData.get('first_name') as string;
+    const lastName = formData.get('last_name') as string;
+    const organizationName = formData.get('organization_name') as string;
+    const organizationSize = formData.get('organization_size') as string;
+
+    if (!email || !password || !organizationName || !organizationSize) {
+      setError('Please fill in all required fields');
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      await AuthManager.signUp({
+        email,
+        password,
+        organization_name: organizationName,
+        organization_size: parseInt(organizationSize, 10),
+        first_name: firstName || undefined,
+        last_name: lastName || undefined,
+      });
+
+      router.push('/app/dashboard');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Registration failed');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Card size="4" style={{ backgroundColor: 'white', width: '100%' }} variant="surface">
+      <Flex direction="column" gap="4" className="mt-0">
+        <Heading size="6" align="center" mx="0" className="flex flex-col items-center mt-0">
+          <Logo width={250} height={100} className="mb-4 mx-auto" />
+          <Text size="5" weight="medium">
+            Create your account
+          </Text>
+        </Heading>
+
+        {error && (
+          <Text color="red" size="2" align="center">
+            {error}
+          </Text>
+        )}
+
+        <Form.Root onSubmit={handleSubmit} className="space-y-3">
+          <Form.Field name="email">
+            <Form.Label>
+              <Text size="2" weight="medium">
+                Email
+              </Text>
+            </Form.Label>
+            <Form.Control asChild>
+              <input
+                type="email"
+                name="email"
+                placeholder="Enter your email"
+                required
+                className="w-full px-3 py-2 text-base bg-white border rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500"
+              />
+            </Form.Control>
+            <Form.Message match="valueMissing">
+              <Text size="1" color="red">
+                Please enter your email
+              </Text>
+            </Form.Message>
+            <Form.Message match="typeMismatch">
+              <Text size="1" color="red">
+                Please enter a valid email
+              </Text>
+            </Form.Message>
+          </Form.Field>
+
+          <Form.Field name="password">
+            <Form.Label>
+              <Text size="2" weight="medium">
+                Password
+              </Text>
+            </Form.Label>
+            <Form.Control asChild>
+              <input
+                type="password"
+                name="password"
+                placeholder="Enter your password"
+                required
+                className="w-full px-3 py-2 text-base bg-white border rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500"
+              />
+            </Form.Control>
+            <Form.Message match="valueMissing">
+              <Text size="1" color="red">
+                Please enter a password
+              </Text>
+            </Form.Message>
+          </Form.Field>
+
+          <Form.Field name="first_name">
+            <Form.Label>
+              <Text size="2" weight="medium">
+                First Name
+              </Text>
+            </Form.Label>
+            <Form.Control asChild>
+              <input
+                type="text"
+                name="first_name"
+                placeholder="First name (optional)"
+                className="w-full px-3 py-2 text-base bg-white border rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500"
+              />
+            </Form.Control>
+          </Form.Field>
+
+          <Form.Field name="last_name">
+            <Form.Label>
+              <Text size="2" weight="medium">
+                Last Name
+              </Text>
+            </Form.Label>
+            <Form.Control asChild>
+              <input
+                type="text"
+                name="last_name"
+                placeholder="Last name (optional)"
+                className="w-full px-3 py-2 text-base bg-white border rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500"
+              />
+            </Form.Control>
+          </Form.Field>
+
+          <Form.Field name="organization_name">
+            <Form.Label>
+              <Text size="2" weight="medium">
+                Organization Name
+              </Text>
+            </Form.Label>
+            <Form.Control asChild>
+              <input
+                type="text"
+                name="organization_name"
+                placeholder="Organization"
+                required
+                className="w-full px-3 py-2 text-base bg-white border rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500"
+              />
+            </Form.Control>
+            <Form.Message match="valueMissing">
+              <Text size="1" color="red">
+                Please enter your organization name
+              </Text>
+            </Form.Message>
+          </Form.Field>
+
+          <Form.Field name="organization_size">
+            <Form.Label>
+              <Text size="2" weight="medium">
+                Organization Size
+              </Text>
+            </Form.Label>
+            <Form.Control asChild>
+              <Select.Root defaultValue="1" name="organization_size">
+                <Select.Trigger className="w-full px-3 py-2 text-base bg-white border rounded-md" />
+                <Select.Content>
+                  <Select.Item value="1">0-1 Employees</Select.Item>
+                  <Select.Item value="2">2-9 Employees</Select.Item>
+                  <Select.Item value="3">10-49 Employees</Select.Item>
+                  <Select.Item value="4">50-249 Employees</Select.Item>
+                  <Select.Item value="5">250+ Employees</Select.Item>
+                </Select.Content>
+              </Select.Root>
+            </Form.Control>
+          </Form.Field>
+
+          <Form.Submit asChild>
+            <Button
+              size="3"
+              style={{ width: '100%', padding: '1rem', marginTop: '10px' }}
+              disabled={isLoading}
+            >
+              {isLoading ? 'Registering...' : 'Sign Up'}
+            </Button>
+          </Form.Submit>
+        </Form.Root>
+      </Flex>
+    </Card>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,6 +2,8 @@
 
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { Button, Card, Flex, Heading } from '@radix-ui/themes';
 
 export default async function Home() {
   const cookieStore = await cookies();
@@ -9,7 +11,23 @@ export default async function Home() {
 
   if (isLoggedIn) {
     redirect('/app/dashboard');
-  } else {
-    redirect('/login');
   }
+
+  return (
+    <div className="h-screen flex items-center justify-center bg-gradient-to-br from-yellow-50 to-white">
+      <Card size="4" style={{ backgroundColor: 'white' }} variant="surface">
+        <Flex direction="column" gap="4" align="center">
+          <Heading size="6">Welcome to HireWise AI</Heading>
+          <Flex gap="3" mt="2">
+            <Button asChild size="3">
+              <Link href="/login">Login</Link>
+            </Button>
+            <Button asChild size="3" variant="outline">
+              <Link href="/sign-up">Sign Up</Link>
+            </Button>
+          </Flex>
+        </Flex>
+      </Card>
+    </div>
+  );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -10,6 +10,24 @@ export interface LoginResponse {
   token_type: string;
 }
 
+export interface SignUpRequest {
+  email: string;
+  password: string;
+  organization_name: string;
+  organization_size: number;
+  first_name?: string;
+  last_name?: string;
+}
+
+export interface ResetPasswordRequest {
+  email: string;
+}
+
+export interface PasswordReset {
+  reset_token: string;
+  new_password: string;
+}
+
 export interface ApiError {
   detail: string;
 }
@@ -86,6 +104,56 @@ class ApiClient {
     if (!response.ok) {
       const errorData: ApiError = await response.json();
       throw new Error(errorData.detail || 'Logout failed');
+    }
+  }
+
+  async signUp(data: SignUpRequest): Promise<LoginResponse> {
+    const response = await fetch(`${this.baseUrl}/api/v1/auth/sign-up`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const errorData: ApiError = await response.json();
+      throw new Error(errorData.detail || 'Registration failed');
+    }
+
+    return response.json();
+  }
+
+  async requestPasswordReset(email: string): Promise<void> {
+    const response = await fetch(`${this.baseUrl}/api/v1/auth/request-password-reset`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ email }),
+    });
+
+    if (!response.ok) {
+      const errorData: ApiError = await response.json();
+      throw new Error(errorData.detail || 'Request failed');
+    }
+  }
+
+  async resetPassword(data: PasswordReset): Promise<void> {
+    const response = await fetch(`${this.baseUrl}/api/v1/auth/reset-password`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const errorData: ApiError = await response.json();
+      throw new Error(errorData.detail || 'Password reset failed');
     }
   }
 }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,4 +1,10 @@
-import { apiClient, LoginRequest, LoginResponse } from './api';
+import {
+  apiClient,
+  LoginRequest,
+  LoginResponse,
+  SignUpRequest,
+  PasswordReset,
+} from './api';
 
 const TOKEN_KEY = 'token';
 const TENANT_ID_KEY = 'tenant_id';
@@ -67,6 +73,16 @@ export class AuthManager {
     }
   }
 
+  static async signUp(data: SignUpRequest): Promise<LoginResponse> {
+    try {
+      const response = await apiClient.signUp(data);
+      this.setToken(response.access_token);
+      return response;
+    } catch (error) {
+      throw error;
+    }
+  }
+
   static async logout(): Promise<void> {
     const token = this.getToken();
 
@@ -87,6 +103,14 @@ export class AuthManager {
     if (typeof window !== 'undefined') {
       window.location.href = '/login';
     }
+  }
+
+  static async requestPasswordReset(email: string): Promise<void> {
+    await apiClient.requestPasswordReset(email);
+  }
+
+  static async resetPassword(data: PasswordReset): Promise<void> {
+    await apiClient.resetPassword(data);
   }
 
   static isAuthenticated(): boolean {


### PR DESCRIPTION
## Summary
- add sign-up page
- add password reset page
- implement API helpers for sign up and password reset
- expose helper functions in `AuthManager`
- update default page with login/sign-up buttons

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/...)*
- `pnpm type-check` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/...)*
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/...)*

------
https://chatgpt.com/codex/tasks/task_b_683a5698d5f4832ba220cb413b9d9530